### PR TITLE
週間予報に横浜を追加

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,12 @@ server.listen(process.env.PORT || 3000);
 
 const bot = new line.Client(line_config);
 
+let selectArea = null
+
 // ルーターの設定
 server.post('/bot/webhook', line.middleware(line_config), (req, res, next) => {
   res.sendStatus(200);
   let events_processed = [];
-  let selectArea = null
   // イベントオブジェクトを順次処理
   req.body.events.forEach((event) => {
     if(event.type == 'message' && event.message.type == 'text') {

--- a/index.js
+++ b/index.js
@@ -33,14 +33,14 @@ server.post('/bot/webhook', line.middleware(line_config), (req, res, next) => {
   req.body.events.forEach((event) => {
     if(event.type == 'message' && event.message.type == 'text') {
       switch(event.message.text) {
-        case 1:
+        case "1":
           selectArea = new Area(tokyoAreaId)
           events_processed.push(bot.replyMessage(event.replyToken, {
             type: 'text',
             text: `天気予報表示地域を${selectArea.name}に設定しました`
           }))
           break
-        case 2:
+        case "2":
           selectArea = new Area(yokohamaAreaId)
           events_processed.push(bot.replyMessage(event.replyToken, {
             type: 'text',

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const server = require("express")();
 const line = require("@line/bot-sdk");
 const axios = require("axios");
+const Area = require("./src/area");
 
 // パラメーターの設定(LINE)
 const line_config = {
@@ -26,6 +27,14 @@ server.post('/bot/webhook', line.middleware(line_config), (req, res, next) => {
   // イベントオブジェクトを順次処理
   req.body.events.forEach((event) => {
     if(event.type == 'message' && event.message.type == 'text') {
+      if(event.message.text == 1) {
+        let tokyo = new Area(1850144)
+        const testStr = `${tokyo.id}\n${tokyo.name}\n${tokyo.lat}\n${tokyo.lon}`
+        events_processed.push(bot.replyMessage(event.replyToken, {
+          type: 'text',
+          text: testStr
+        }))
+      }
       if(event.message.text == '週間予報'){
         axios.get(apiUrl, {
           params: {

--- a/index.js
+++ b/index.js
@@ -10,26 +10,27 @@ const line_config = {
   channelSecret: process.env.LINE_CHANNEL_SECRET
 };
 
-// 天気予報APIのパラメーター
-const lat = 35.689499
-const lon = 139.691711
+// 初期座標(東京)
+const defaultLat = 35.689499
+const defaultLon = 139.691711
+// 天気予報APIのURL
 const apiUrl = "https://api.openweathermap.org/data/2.5/onecall";
 
 // 地域ID
 const tokyoAreaId = 1850144
 const yokohamaAreaId = 1848354
+// 天気予報表示設定地域
+let selectArea = null
 
 // Webサーバーの設定
 server.listen(process.env.PORT || 3000);
 
 const bot = new line.Client(line_config);
 
-let selectArea = null
-
 // ルーターの設定
 server.post('/bot/webhook', line.middleware(line_config), (req, res, next) => {
-  res.sendStatus(200);
-  let events_processed = [];
+  res.sendStatus(200)
+  let events_processed = []
   // イベントオブジェクトを順次処理
   req.body.events.forEach((event) => {
     if(event.type == 'message' && event.message.type == 'text') {
@@ -51,8 +52,8 @@ server.post('/bot/webhook', line.middleware(line_config), (req, res, next) => {
         case "週間予報":
           axios.get(apiUrl, {
             params: {
-              lat: selectArea == null ? lat : selectArea.lat,
-              lon: selectArea == null ? lon : selectArea.lon,
+              lat: selectArea == null ? defaultLat : selectArea.lat,
+              lon: selectArea == null ? defaultLon : selectArea.lon,
               lang: "ja",
               appid: process.env.OPEN_WEATHER_API_APPID
             },
@@ -64,7 +65,7 @@ server.post('/bot/webhook', line.middleware(line_config), (req, res, next) => {
           })
           .then(res => {
             // 返信内容を設定してユーザーに送信
-            let week_weather = ""
+            let week_weather = selectArea == null ? "東京の天気\n" : `${selectArea.name}の天気\n`
             for(i = 0; i < res.data.daily.length; i++) {
               if(i < res.data.daily.length - 1) {
                 week_weather += responseMessage(res.data.daily[i]) + "\n\n"

--- a/index.js
+++ b/index.js
@@ -32,57 +32,59 @@ server.post('/bot/webhook', line.middleware(line_config), (req, res, next) => {
   // イベントオブジェクトを順次処理
   req.body.events.forEach((event) => {
     if(event.type == 'message' && event.message.type == 'text') {
-      if(event.message.text == 1) {
-        selectArea = new Area(tokyoAreaId)
-        events_processed.push(bot.replyMessage(event.replyToken, {
-          type: 'text',
-          text: `天気予報表示地域を${selectArea.name}に設定しました`
-        }))
-      } else if(event.message.text == 2) {
-        selectArea = new Area(yokohamaAreaId)
-        events_processed.push(bot.replyMessage(event.replyToken, {
-          type: 'text',
-          text: `天気予報表示地域を${selectArea.name}に設定しました`
-        }))
-      }
-
-      if(event.message.text == '週間予報'){
-        axios.get(apiUrl, {
-          params: {
-            lat: selectArea == null ? lat : selectArea.lat,
-            lon: selectArea == null ? lon : selectArea.lon,
-            lang: "ja",
-            appid: process.env.OPEN_WEATHER_API_APPID
-          },
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json'
-          },
-          responseType: 'json'
-        })
-        .then(res => {
-          // 返信内容を設定してユーザーに送信
-          let week_weather = ""
-          for(i = 0; i < res.data.daily.length; i++) {
-            if(i < res.data.daily.length - 1) {
-              week_weather += responseMessage(res.data.daily[i]) + "\n\n"
-            } else {
-              week_weather += responseMessage(res.data.daily[i])
+      switch(event.message.text) {
+        case 1:
+          selectArea = new Area(tokyoAreaId)
+          events_processed.push(bot.replyMessage(event.replyToken, {
+            type: 'text',
+            text: `天気予報表示地域を${selectArea.name}に設定しました`
+          }))
+          break
+        case 2:
+          selectArea = new Area(yokohamaAreaId)
+          events_processed.push(bot.replyMessage(event.replyToken, {
+            type: 'text',
+            text: `天気予報表示地域を${selectArea.name}に設定しました`
+          }))
+          break
+        case "週間予報":
+          axios.get(apiUrl, {
+            params: {
+              lat: selectArea == null ? lat : selectArea.lat,
+              lon: selectArea == null ? lon : selectArea.lon,
+              lang: "ja",
+              appid: process.env.OPEN_WEATHER_API_APPID
+            },
+            headers: {
+              Accept: 'application/json',
+              'Content-Type': 'application/json'
+            },
+            responseType: 'json'
+          })
+          .then(res => {
+            // 返信内容を設定してユーザーに送信
+            let week_weather = ""
+            for(i = 0; i < res.data.daily.length; i++) {
+              if(i < res.data.daily.length - 1) {
+                week_weather += responseMessage(res.data.daily[i]) + "\n\n"
+              } else {
+                week_weather += responseMessage(res.data.daily[i])
+              }
             }
-          }
-          events_processed.push(bot.replyMessage(event.replyToken, {
-            type: 'text',
-            text: week_weather
-          }))
-          
-        })
-        .catch(err => {
-          // エラーメッセージを設定してユーザーに送信
-          events_processed.push(bot.replyMessage(event.replyToken, {
-            type: 'text',
-            text: 'APIの実行に失敗'
-          }))
-        })
+            events_processed.push(bot.replyMessage(event.replyToken, {
+              type: 'text',
+              text: week_weather
+            }))
+          })
+          .catch(err => {
+            // エラーメッセージを設定してユーザーに送信
+            events_processed.push(bot.replyMessage(event.replyToken, {
+              type: 'text',
+              text: 'APIの実行に失敗'
+            }))
+          })
+          break
+        default:
       }
     }
   });

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const server = require("express")();
 const line = require("@line/bot-sdk");
 const axios = require("axios");
-const Area = require("./src/area")
+const areaModule = require("./src/area")
 
 // パラメーターの設定(LINE)
 const line_config = {
@@ -16,9 +16,6 @@ const defaultLon = 139.691711
 // 天気予報APIのURL
 const apiUrl = "https://api.openweathermap.org/data/2.5/onecall";
 
-// 地域ID
-const tokyoAreaId = 1850144
-const yokohamaAreaId = 1848354
 // 天気予報表示設定地域
 let selectArea = null
 
@@ -36,14 +33,14 @@ server.post('/bot/webhook', line.middleware(line_config), (req, res, next) => {
     if(event.type == 'message' && event.message.type == 'text') {
       switch(event.message.text) {
         case "1":
-          selectArea = new Area(tokyoAreaId)
+          selectArea = new areaModule.Area(areaModule.tokyoAreaId)
           events_processed.push(bot.replyMessage(event.replyToken, {
             type: 'text',
             text: `天気予報表示地域を${selectArea.name}に設定しました`
           }))
           break
         case "2":
-          selectArea = new Area(yokohamaAreaId)
+          selectArea = new areaModule.Area(areaModule.yokohamaAreaId)
           events_processed.push(bot.replyMessage(event.replyToken, {
             type: 'text',
             text: `天気予報表示地域を${selectArea.name}に設定しました`

--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ const lat = 35.689499
 const lon = 139.691711
 const apiUrl = "https://api.openweathermap.org/data/2.5/onecall";
 
+// 地域ID
+const tokyoAreaId = 1850144
+const yokohamaAreaId = 1848354
+
 // Webサーバーの設定
 server.listen(process.env.PORT || 3000);
 
@@ -24,17 +28,24 @@ const bot = new line.Client(line_config);
 server.post('/bot/webhook', line.middleware(line_config), (req, res, next) => {
   res.sendStatus(200);
   let events_processed = [];
+  let selectArea = null
   // イベントオブジェクトを順次処理
   req.body.events.forEach((event) => {
     if(event.type == 'message' && event.message.type == 'text') {
       if(event.message.text == 1) {
-        let tokyo = new Area(1850144)
-        const testStr = `${tokyo.id}\n${tokyo.name}\n${tokyo.lat}\n${tokyo.lon}`
+        selectArea = new Area(tokyoAreaId)
         events_processed.push(bot.replyMessage(event.replyToken, {
           type: 'text',
-          text: testStr
+          text: `天気予報表示地域を${selectArea.name}に設定しました`
+        }))
+      } else if(event.message.text == 2) {
+        selectArea = new Area(yokohamaAreaId)
+        events_processed.push(bot.replyMessage(event.replyToken, {
+          type: 'text',
+          text: `天気予報表示地域を${selectArea.name}に設定しました`
         }))
       }
+
       if(event.message.text == '週間予報'){
         axios.get(apiUrl, {
           params: {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const server = require("express")();
 const line = require("@line/bot-sdk");
 const axios = require("axios");
-import Area from "./src/area"
+const Area = require("./src/area")
 
 // パラメーターの設定(LINE)
 const line_config = {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const server = require("express")();
 const line = require("@line/bot-sdk");
 const axios = require("axios");
-const Area = require("./src/area");
+import Area from "./src/area"
 
 // パラメーターの設定(LINE)
 const line_config = {

--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ server.post('/bot/webhook', line.middleware(line_config), (req, res, next) => {
       if(event.message.text == '週間予報'){
         axios.get(apiUrl, {
           params: {
-            lat: lat,
-            lon: lon,
+            lat: selectArea == null ? lat : selectArea.lat,
+            lon: selectArea == null ? lon : selectArea.lon,
             lang: "ja",
             appid: process.env.OPEN_WEATHER_API_APPID
           },

--- a/src/area.js
+++ b/src/area.js
@@ -22,4 +22,4 @@ class Area {
   }
 }
 
-export default class { Area }
+module.exports = Area

--- a/src/area.js
+++ b/src/area.js
@@ -1,0 +1,25 @@
+// 地域リスト
+const areaList = {
+  1850144: {
+    name: "東京",
+    lat: 35.689499,
+    lon: 139.691711
+  },
+  1848354: {
+    name: "横浜",
+    lat: 35.447781,
+    lon: 139.642502
+  }
+}
+
+// Areaクラス(地域クラス)
+class Area {
+  constructor(id) {
+    this.id = id
+    this.name = areaList[id].name
+    this.lat = areaList[id].lat
+    this.lon = areaList[id].lon
+  }
+}
+
+export default Area

--- a/src/area.js
+++ b/src/area.js
@@ -1,3 +1,7 @@
+// 地域ID
+const tokyoAreaId = 1850144
+const yokohamaAreaId = 1848354
+
 // 地域リスト
 const areaList = {
   1850144: {
@@ -22,4 +26,8 @@ class Area {
   }
 }
 
-module.exports = Area
+module.exports = {
+  Area: Area,
+  tokyoAreaId: tokyoAreaId,
+  yokohamaAreaId: yokohamaAreaId
+}

--- a/src/area.js
+++ b/src/area.js
@@ -22,4 +22,4 @@ class Area {
   }
 }
 
-export default Area
+export default class { Area }


### PR DESCRIPTION
天気予報を出力する地域に「横浜」を追加する

- [x] 横浜の緯度・経度を調べる
- [x] 東京と横浜の地域IDを調べる
- [x] Areaクラスを作成する
IDを渡して東京or横浜を識別する
[クラスパラメーター]
・id(地域ID)：数値
・name(地域名)：文字列
・lat(緯度)：数値
・lon(経度)：数値
- [x] 1を入力すると「東京」2を入力すると「横浜」を出力地域に設定する
※何も設定しない場合は「東京」予報を出力させる
- [x] 設定した地域の天気予報が出力されているか確認する
- [x] 地域設定の処理を統一化できるか検討
統一化は後日検討

[基本手順]
①1or2を入力して地域を設定
②「週間予報」と入力すると設定した地域の予報を出力