### PR TITLE
降水確率の小数点を切り上げする

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function responseMessage(daily_data) {
   return `${unixtimeToDate(daily_data.dt)} ${getWeatherEmoji(daily_data.weather[0].main)}
 最高気温：${kelvinToCelsius(daily_data.temp.max)}度
 最低気温：${kelvinToCelsius(daily_data.temp.min)}度
-降水確率：${daily_data.pop * 100}%`
+降水確率：${Math.floor(daily_data.pop * 100)}%`
 }
 
 // unix時間の変換


### PR DESCRIPTION
降水確率の小数点の切り上げ処理を行なっていなかったため、APIから取得した値によっては小数点まで表示されてしまいフォーマットが崩れる。

- [ ] 降水確率の小数点を切り上げする